### PR TITLE
URI encode request url

### DIFF
--- a/lib/nerves_hub_user_api/api.ex
+++ b/lib/nerves_hub_user_api/api.ex
@@ -26,13 +26,18 @@ defmodule NervesHubUserAPI.API do
 
   def request(:get, path, params) when is_map(params) do
     client()
-    |> request(method: :get, url: path, query: Map.to_list(params), opts: [adapter: opts(%{})])
+    |> request(
+      method: :get,
+      url: URI.encode(path),
+      query: Map.to_list(params),
+      opts: [adapter: opts(%{})]
+    )
     |> resp()
   end
 
   def request(verb, path, params, auth \\ %{}) do
     client()
-    |> request(method: verb, url: path, body: params, opts: [adapter: opts(auth)])
+    |> request(method: verb, url: URI.encode(path), body: params, opts: [adapter: opts(auth)])
     |> resp()
   end
 
@@ -61,7 +66,7 @@ defmodule NervesHubUserAPI.API do
           end).()
 
     client()
-    |> request(method: verb, url: path, body: mp, opts: [adapter: opts(auth)])
+    |> request(method: verb, url: URI.encode(path), body: mp, opts: [adapter: opts(auth)])
     |> resp()
   end
 


### PR DESCRIPTION
~~CLI counterpart of https://github.com/nerves-hub/nerves_hub_web/pull/493~~

~~If a device identifier has a space, it becomes unmanageable from the CLI because that gets sent as a `+` (i.e. `"device 1234" -> device+1234`). So this makes a change to `URI.encode/1` the org name or device identifier in requests so that they are transmitted correctly.~~

EDIT:
If some part of a path has a space or other unsafe URI character, the whole request will fail. This changes to do `URI.encode/1` on any path that is sent for a request to cover multiple bases.
    
Further validation to be done in NervesHubWebCore