### PR TITLE
Enable verify peer on ssl connections

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,8 @@ config :nerves_hub_user_api,
   host: "0.0.0.0",
   port: 5002,
   # pass list of paths
-  ca_certs: Path.expand("test/fixtures/ssl")
+  ca_certs: Path.expand("test/fixtures/ssl"),
+  server_name_indication: :disable
 
 alias NervesHubCA.Intermediate.CA
 

--- a/lib/nerves_hub_user_api/api.ex
+++ b/lib/nerves_hub_user_api/api.ex
@@ -95,12 +95,19 @@ defmodule NervesHubUserAPI.API do
 
   defp ssl_options(%{key: key, cert: cert}) do
     [
+      verify: :verify_peer,
+      server_name_indication: server_name_indication(),
       key: {:ECPrivateKey, X509.PrivateKey.to_der(key)},
       cert: X509.Certificate.to_der(cert)
     ]
   end
 
   defp ssl_options(_), do: []
+
+  defp server_name_indication do
+    Application.get_env(:nerves_hub_user_api, :server_name_indication) ||
+      Application.get_env(:nerves_hub_user_api, :host) |> to_charlist()
+  end
 
   def put_progress(size, max) do
     fraction = size / max


### PR DESCRIPTION
This enabled verify peer in the ssl options and allows the `server_name_indication` to be specified, or disabled in the application configuration. The `server_name_indication` defaults to the host.