### PR TITLE
Adds description to ca cert create def

### DIFF
--- a/lib/nerves_hub_user_api/ca_certificate.ex
+++ b/lib/nerves_hub_user_api/ca_certificate.ex
@@ -27,10 +27,13 @@ defmodule NervesHubUserAPI.CACertificate do
   Verb: POST
   Path: /orgs/:org_name/ca_certificates
   """
-  @spec create(String.t(), String.t(), NervesHubUserAPI.Auth.t()) ::
+  @spec create(String.t(), String.t(), NervesHubUserAPI.Auth.t(), String.t()) ::
           {:error, any()} | {:ok, any()}
-  def create(org_name, cert_pem, %Auth{} = auth) do
-    params = %{cert: Base.encode64(cert_pem)}
+  def create(org_name, cert_pem, %Auth{} = auth, description \\ nil) do
+    params = %{
+      cert: Base.encode64(cert_pem),
+      description: description
+    }
     API.request(:post, path(org_name), params, auth)
   end
 

--- a/test/nerves_hub_user_api/ca_certificate_test.exs
+++ b/test/nerves_hub_user_api/ca_certificate_test.exs
@@ -14,6 +14,14 @@ defmodule NervesHubCoreTest.CACertificateTest do
 
       assert {:ok, _} = CACertificate.create(user["username"], cert_pem, auth)
     end
+
+    test "valid with description", %{user: user, auth: auth} do
+      key = X509.PrivateKey.new_ec(:secp256r1)
+      cert = X509.Certificate.self_signed(key, "CN=My CA", template: :root_ca)
+      cert_pem = X509.Certificate.to_pem(cert)
+
+      assert {:ok, _} = CACertificate.create(user["username"], cert_pem, auth, "test")
+    end
   end
 
   describe "list" do


### PR DESCRIPTION
Need these changes as well as nerves-hub/nerves_hub_web#663 then we should be able to add a description option to `nerves_hub_cli`.
connects to #22
connect nerves-hub/nerves_hub_web#660