### PR TITLE
use pkix_verify_hostname_match_fun for SNI validation

### DIFF
--- a/lib/nerves_hub_user_api/api.ex
+++ b/lib/nerves_hub_user_api/api.ex
@@ -97,7 +97,8 @@ defmodule NervesHubUserAPI.API do
       [
         verify: :verify_peer,
         server_name_indication: server_name_indication(),
-        cacerts: ca_certs()
+        cacerts: ca_certs(),
+        customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
       ] ++ peer_options(auth)
 
     [


### PR DESCRIPTION
Use expected semantics when validating a hostname -- hostname wildcards are disabled by default in Erlang, adding this SSL configuration option allows wildcard hostnames.